### PR TITLE
Don't use same argument name

### DIFF
--- a/emlib-math.el
+++ b/emlib-math.el
@@ -239,7 +239,7 @@ Make sure B > A. Otherwise `random' would ignore its argument."
 
 (defun emlib-rand-mat (i j)
   "Generate a matrix of I x J order with random elements."
-  (emlib-mat-create (lambda (_ _)
+  (emlib-mat-create (lambda (_a _b)
                       (emlib-rand -1 1))
                     i
                     j))

--- a/emlib-nn.el
+++ b/emlib-nn.el
@@ -38,7 +38,7 @@ sure that we can support momentum while updating the weights.  An
 vector of error terms is also kept in the layer property list to
 aid the back propagation step."
   (let* ((w (emlib-rand-mat h i))
-         (dw (emlib-mat-create (lambda (_ _) 0) h i))
+         (dw (emlib-mat-create (lambda (_a _b) 0) h i))
          (o (emlib-vec-create (lambda (_) 0) h))
          (eterms (emlib-vec-create (lambda (_) 0) h)))
     (list :weights w


### PR DESCRIPTION
This causes byte-compile warning.